### PR TITLE
Include Plausible 

### DIFF
--- a/links/links/html/home.html
+++ b/links/links/html/home.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script src="https://cdn.tailwindcss.com"></script>
+    <script defer data-domain="danielms.site" src="https://plausible.io/js/plausible.js"></script>
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <title>Daniel Michaels Links</title>
 </head>


### PR DESCRIPTION
This adds the [Plausbile](https://plausible.io) analytics script tag to the `links` faas template.

It has been deployed already.