### PR TITLE
Timesheet: UTC cron update

### DIFF
--- a/timesheet-calculator/timesheet-calculator.yml
+++ b/timesheet-calculator/timesheet-calculator.yml
@@ -24,6 +24,6 @@ functions:
       - mail-username
     annotations:
       topic: cron-function
-      schedule: "15 21 * * *"
+      schedule: "15 0 * * *"
 
 


### PR DESCRIPTION
Update the crontab to be my current day in UTC, i.e. 00:15 of Tuesday is 10:15 of Tuesday for me. This fixes the delay issue of using UTC with a daytime checker in the code.

A better solution should be worked on in the future.