### PR TITLE
New Contract Dates

### DIFF
--- a/timesheet-calculator/timesheet-calculator/handler.go
+++ b/timesheet-calculator/timesheet-calculator/handler.go
@@ -14,8 +14,9 @@ import (
 )
 
 var (
-	timesheetDb = "/tmp/database.db"
-	toEmail     = "dan@danielms.site"
+	timesheetDb          = "/tmp/database.db"
+	toEmail              = "dan@danielms.site"
+	totalContractedHours = 392 * 8 // days * expected hours per day
 )
 
 type result struct {
@@ -105,7 +106,6 @@ func Handle(w http.ResponseWriter, r *http.Request) {
 		total += v.TotalTime
 	}
 
-	totalContractedHours := 392 * 8
 	avgHourDaily, err := app.Cal.MeanDaily(totalContractedHours, total)
 	if err != nil {
 		handlers.ServerError(w, r, err)

--- a/timesheet-calculator/timesheet-calculator/handlers/models.go
+++ b/timesheet-calculator/timesheet-calculator/handlers/models.go
@@ -181,10 +181,11 @@ func (c *ContractCalendar) DaysLeftThisMonth() int {
 }
 
 func (c *ContractCalendar) IsFriday() bool {
-	if time.Now().Weekday() == time.Friday {
-		return true
-	}
-	return false
+	return time.Now().Weekday() == time.Friday
+}
+
+func (c *ContractCalendar) IsSaturday() bool {
+	return time.Now().Weekday() == time.Saturday
 }
 
 func (c *ContractCalendar) IsEndOfMonth() bool {

--- a/timesheet-calculator/timesheet-calculator/handlers/models.go
+++ b/timesheet-calculator/timesheet-calculator/handlers/models.go
@@ -180,10 +180,6 @@ func (c *ContractCalendar) DaysLeftThisMonth() int {
 	return c.Calendar.WorkdaysInRange(time.Now(), remainder)
 }
 
-func (c *ContractCalendar) IsFriday() bool {
-	return time.Now().Weekday() == time.Friday
-}
-
 func (c *ContractCalendar) IsSaturday() bool {
 	return time.Now().Weekday() == time.Saturday
 }

--- a/timesheet-calculator/timesheet-calculator/handlers/timesheet.go
+++ b/timesheet-calculator/timesheet-calculator/handlers/timesheet.go
@@ -9,8 +9,7 @@ import (
 )
 
 var (
-	OldContractEnd = time.Date(2022, 11, 30, 0, 0, 0, 00, time.UTC)
-	NewContractEnd = time.Date(2024, 07, 00, 0, 0, 0, 00, time.UTC)
+	ContractEnd = time.Date(2024, 07, 00, 0, 0, 0, 00, time.UTC)
 )
 
 func secondsToHours(secs int) (time.Duration, error) {


### PR DESCRIPTION
Update timesheet to reflect new contract. Change end of week to be Saturday

Using Friday will miss Friday's work hours. The end of month will also causes issues but that will be addressed later (misses one day and isn't a huge deal).